### PR TITLE
Add swim style to competition screen

### DIFF
--- a/public/competition/screen.html
+++ b/public/competition/screen.html
@@ -31,6 +31,7 @@
         <div class="logofont-bold">AZC</div>
         <span class="text-3xl" id="stopwatch">00:00:00</span>
         <span>Event: <span id="event-heat">1-1</span></span>
+        <span id="swim-style"></span>
     </div>
     <table class="w-full text-2xl">
         <tbody>

--- a/public/competition/screen.html
+++ b/public/competition/screen.html
@@ -27,11 +27,15 @@
     </style>
 </head>
 <body>
-    <div class="top-bar flex justify-between items-center bg-blue-600 text-white py-1 px-2 text-2xl">
+    <div class="top-bar flex justify-between items-center bg-blue-600 text-white py-1 px-4 text-2xl">
         <div class="logofont-bold">AZC</div>
         <span class="text-3xl" id="stopwatch">00:00:00</span>
-        <span>Event: <span id="event-heat">1-1</span></span>
-        <span id="swim-style"></span>
+        <div> 
+            <span>Event: <span id="event-heat">1 - 1</span></span> | 
+            <span id="swim-style"></span>
+        </div>
+       
+        
     </div>
     <table class="w-full text-2xl">
         <tbody>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const incrementEventButton = document.getElementById('increment-event');
     const incrementHeatButton = document.getElementById('increment-heat');
     const connectionIndicator = document.getElementById('connection-indicator');
+    const swimStyleElement = document.getElementById('swim-style');
     let socket;
     let connectionCheckInterval;
 
@@ -235,6 +236,9 @@ document.addEventListener('DOMContentLoaded', function () {
             .then(response => response.json())
             .then(data => {
                 updateLaneInformation(data.entries);
+                if (swimStyleElement) {
+                    swimStyleElement.textContent = data.event.swimstyle;
+                }
             })
             .catch(error => {
                 clearLaneInformation();

--- a/server/modules/competition.js
+++ b/server/modules/competition.js
@@ -163,6 +163,14 @@ const getCompetitionEvents = (req, res) => {
     res.send(JSON.stringify(events));
 };
 
+const formatSwimStyle = (swimstyle) => {
+    const { distance, relaycount, stroke } = swimstyle;
+    if (relaycount > 1) {
+        return `${relaycount} x ${distance}M ${stroke}`;
+    }
+    return `${distance}M ${stroke}`;
+};
+
 const getCompetition = (req, res) => {
     let eventNumber = parseInt(req.query.event);
     let heatNumber = parseInt(req.query.heat);
@@ -203,7 +211,7 @@ const getCompetition = (req, res) => {
             number: event.number,
             order: event.order,
             eventid: event.event,
-            swimstyle: event.swimstyle,
+            swimstyle: formatSwimStyle(event.swimstyle),
             heatCount: event.heats.length,
         },
         heat: heat,

--- a/server/modules/competition.js
+++ b/server/modules/competition.js
@@ -165,10 +165,18 @@ const getCompetitionEvents = (req, res) => {
 
 const formatSwimStyle = (swimstyle) => {
     const { distance, relaycount, stroke } = swimstyle;
+    const strokeTranslation = {
+        FREE: 'Vrije slag',
+        BACK: 'Rugslag',
+        MEDLEY: 'Wisselslag',
+        BREAST: 'Schoolslag',
+        FLY: 'Vlinderslag'
+    };
+    const translatedStroke = strokeTranslation[stroke] || stroke;
     if (relaycount > 1) {
-        return `${relaycount} x ${distance}M ${stroke}`;
+        return `${relaycount} x ${distance}M ${translatedStroke}`;
     }
-    return `${distance}M ${stroke}`;
+    return `${distance}M ${translatedStroke}`;
 };
 
 const getCompetition = (req, res) => {


### PR DESCRIPTION
Add swim style formatting to competition screen.

* Add `formatSwimStyle` function in `server/modules/competition.js` to format swim style based on relay count.
* Update `getCompetition` function in `server/modules/competition.js` to use `formatSwimStyle` for formatting swim style.
* Add a new element in `public/competition/screen.html` to display the formatted swim style next to the event-heat span.
* Update `fetchCompetitionData` function in `public/js/main.js` to update the swim style element with the formatted swim style.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spelbreker/ws-swim-stopwatch/pull/28?shareId=e05646f1-1932-4099-ba70-135477456617).