### PR TITLE
Add support to show relays in competition data

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "name": "Node 22 Container",
+    "image": "node:22",
+    "postCreateCommand": "npm install",
+    "customizations": {
+        "vscode": {
+            "settings": {},
+            "extensions": []
+        }
+    }
+}

--- a/public/competition/screen.html
+++ b/public/competition/screen.html
@@ -1,41 +1,54 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Screen</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <style>
-        body{
+        body {
             background-color: #efefef;
         }
+
         .highlight {
-            background-color: #90ee90; /* Light green */
+            background-color: #90ee90;
+            /* Light green */
             transition: background-color 2s ease;
         }
+
         .top-bar {
             height: 10vh;
         }
+
         tr {
             height: calc(82vh / 10);
             font-size: 5vh;
         }
+
         .bottom-bar {
             height: 8vh;
             font-size: 3vh;
         }
     </style>
 </head>
+
 <body>
     <div class="top-bar flex justify-between items-center bg-blue-600 text-white py-1 px-4 text-2xl">
+
         <div class="logofont-bold">AZC</div>
-        <span class="text-3xl" id="stopwatch">00:00:00</span>
-        <div> 
-            <span>Event: <span id="event-heat">1 - 1</span></span> | 
-            <span id="swim-style"></span>
+        <div class="flex flex-col">
+            <div class="text-2xl">
+                <span id="event-number">1</span> - <span id="swim-style"></span>
+            </div>
+            <div class="text-xl">
+                serie <span id="heat-number">1</span>
+            </div>
         </div>
+        <span class="text-3xl" id="stopwatch">00:00:00</span>
        
-        
+
+
     </div>
     <table class="w-full text-2xl">
         <tbody>
@@ -102,8 +115,9 @@
         </tbody>
     </table>
     <div class="bottom-bar bg-blue-600 text-white py-1 px-2 fixed bottom-0 w-full text-center">
-        <div class="bottom-bar-text text-white text-md font-bold">Dit zijn geen officele tijden</div>
+        <div class="bottom-bar-text text-white text-xl font-bold">Dit zijn geen officele tijden</div>
     </div>
     <script src="/public/js/main.js"></script>
 </body>
+
 </html>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -5,7 +5,8 @@ document.addEventListener('DOMContentLoaded', function () {
     let stopwatchInterval;
     let startTime;
     const stopwatchElement = document.getElementById('stopwatch');
-    const eventHeatElement = document.getElementById('event-heat');
+    const heatElement = document.getElementById('heat-number');
+    const eventElement = document.getElementById('event-number');
     const laneButtons = document.querySelectorAll('.lane-button');
     const eventSelect = document.getElementById('event-select');
     const heatSelect = document.getElementById('heat-select');
@@ -55,7 +56,8 @@ document.addEventListener('DOMContentLoaded', function () {
             } else if (message.type === 'event-heat') {
                 fetchCompetitionData(message.event, message.heat);
                 if (isScreenPage) {
-                    eventHeatElement.textContent = `${message.event}-${message.heat}`;
+                    eventElement.textContent = message.event;
+                    heatElement.textContent = message.heat;
                 }
                 if (isRemotePage) {
                     eventSelect.value = message.event;
@@ -257,10 +259,23 @@ document.addEventListener('DOMContentLoaded', function () {
         entries.forEach(entry => {
             entry.forEach(athlete => {
                 const laneElement = document.getElementById(`lane-${athlete.lane}`);
-                laneElement.querySelector('.athlete').textContent = `${athlete.firstname} ${athlete.lastname}`;
+                if (athlete.athletes && athlete.athletes.length > 0) {
+                    //loop through athletes and display firstname
+                    let athleteNames = '';
+                    athlete.athletes.forEach((a, index) => {
+                        athleteNames += `${a.firstname.substring(0, 3)}..`;
+                        if (index < athlete.athletes.length - 1) {
+                            athleteNames += ' / ';
+                        }
+                    });
+                    laneElement.querySelector('.athlete').textContent =  athleteNames;
+                } else {
+                    laneElement.querySelector('.athlete').textContent = `${athlete.firstname} ${athlete.lastname}`;
+                }
                 laneElement.querySelector('.club').textContent = athlete.club;
                 laneElement.querySelector('.split-time').textContent = '---:---:---';
             });
+
         });
     }
 

--- a/server/modules/competition.js
+++ b/server/modules/competition.js
@@ -266,22 +266,22 @@ const extractRelay = (competitionData, event, heat) => {
     let relayEntries = competitionData.meets[0].clubs
         .map((club) => {
             return (club.relays || []).map((relay) => {
-                if (relay.heatid !== heat || relay.eventid !== event) {
+                if (relay.entries[0].heatid !== heat || relay.entries[0].eventid !== event) {
                     return null;
                 }
 
                 return {
                     relayid: relay.relayid,
                     club: club.name,
-                    athletes: relay.athletes.map((athlete) => {
+                    athletes: relay.entries[0].relaypositions.map((position) => {
                         return {
-                            athleteid: athlete.athleteid,
-                            firstname: athlete.firstname,
-                            lastname: athlete.lastname,
+                            athleteid: position.athleteid,
+                            firstname: position.firstname,
+                            lastname: position.lastname,
                         };
                     }),
-                    lane: relay.lane,
-                    entrytime: relay.entrytime,
+                    lane: relay.entries[0].lane,
+                    entrytime: relay.entries[0].entrytime,
                 };
             })
             .filter(Boolean);

--- a/server/modules/competition.js
+++ b/server/modules/competition.js
@@ -262,6 +262,19 @@ const findAthletes = (competitionData, event, heat) => {
     return entries;
 };
 
+const findAthleteById = (competitionData, athleteId) => {
+    for (const club of competitionData.meets[0].clubs) {
+        if (club.athletes) {
+            for (const athlete of club.athletes) {
+                if (athlete.athleteid === athleteId) {
+                    return athlete;
+                }
+            }
+        }
+    }
+    return null;
+};
+
 const extractRelay = (competitionData, event, heat) => {
     let relayEntries = competitionData.meets[0].clubs
         .map((club) => {
@@ -274,10 +287,11 @@ const extractRelay = (competitionData, event, heat) => {
                     relayid: relay.relayid,
                     club: club.name,
                     athletes: relay.entries[0].relaypositions.map((position) => {
+                        let athlete = findAthleteById(competitionData, position.athleteid);
                         return {
                             athleteid: position.athleteid,
-                            firstname: position.firstname,
-                            lastname: position.lastname,
+                            firstname: athlete ? athlete.firstname : '',
+                            lastname: athlete ? athlete.lastname : '',
                         };
                     }),
                     lane: relay.entries[0].lane,
@@ -310,4 +324,5 @@ module.exports = {
     findAthletes,
     getCompetitionSummary,
     deleteCompetition,
+    findAthleteById  // added new function
 };


### PR DESCRIPTION
Add support to show relays in competition data.

* Add a new function `extractRelay` to extract relay information from `meets->clubs->relays`.
* Update the `getCompetition` function to include relay information in the competition data.
* Modify the `findAthletes` function to handle relay entries and include relay teams and their associated clubs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spelbreker/ws-swim-stopwatch/pull/29?shareId=28018d2b-3b9c-4bfe-b3b8-01b264386179).